### PR TITLE
Add Selenium scraper for Freelancer welfare research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# Freelancer-Research
+# Freelancer Welfare Research Scraper
+
+This repository contains a Selenium-based toolkit for collecting public project
+and bid information from [Freelancer.com](https://www.freelancer.com/). The
+utilities are designed to support labour economics and market design research
+questions such as the presence of a winner's curse, access cliffs for new
+entrants, or how employer reputation interacts with bidding behaviour.
+
+## Key Features
+
+- **Search automation** – Iterates over keyword queries and paginated result
+  sets to gather structured project-level data (budgets, bid counts, skills,
+  employer reputation snippets, etc.).
+- **Bid harvesting** – Optionally follows each project to capture bidder level
+  information (bid amount, promised delivery time, bidder reputation metrics),
+  which is essential for studying phenomena like the winner's curse.
+- **Flexible exports** – Save results as JSON or CSV files for downstream
+  analysis in Python, R, or statistical packages.
+- **Polite defaults** – Headless browsing with randomised delays, plus hooks to
+  authenticate via environment variables when deeper data requires login.
+
+## Installation
+
+1. Ensure you have Python 3.10+ installed.
+2. Install the dependencies in a virtual environment:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+   The scraper relies on Google Chrome. Install it locally and make sure it is
+   available on your `PATH`. `webdriver-manager` will download the matching
+   ChromeDriver binary automatically.
+
+## Usage
+
+Run the CLI from the project root to collect project data for one or more
+keywords:
+
+```bash
+python -m freelancer_research.cli \
+  --search "data entry" \
+  --search "python scraping" \
+  --pages 3 \
+  --results-per-page 50 \
+  --include-bids \
+  --max-bids 40 \
+  --output data/projects.json \
+  --bids-output data/bids.csv
+```
+
+### Authentication
+
+Certain project details (especially full bid lists) may require an authenticated
+session. Provide credentials via command-line flags or environment variables
+before running the scraper:
+
+```bash
+export FREELANCER_EMAIL="your-email@example.com"
+export FREELANCER_PASSWORD="your-password"
+python -m freelancer_research.cli --search "machine learning" --include-bids
+```
+
+### Output Structure
+
+- **Project summaries** include the project id, title, description, budget
+  bounds, bid counts, employer reputation snippets, and detected skills. When
+  exported to CSV, skills are pipe-delimited for easier parsing.
+- **Bid level records** (optional) contain project id, bidder username,
+  reputation metrics, offered amount, currency code, stated delivery days, and
+  status. These fields are sufficient to construct panels for welfare analyses
+  such as bid dispersion, newcomer versus incumbent success, or estimating
+  access cliffs.
+
+### Research Considerations
+
+- Respect [Freelancer.com's terms of service](https://www.freelancer.com/info/terms)
+  and rate limits. The provided delays are conservative defaults, but you
+  should still monitor request volume and adapt if you scale up.
+- Store scraped data securely and anonymise user-identifying information when
+  necessary to comply with ethical research guidelines.
+- Combining project budgets with realised bid amounts allows you to test for
+  winner's curse patterns; matching bid histories with bidder tenure helps
+  quantify access cliffs for new freelancers.
+
+## Development
+
+- The codebase intentionally avoids storing credentials. Use environment
+  variables or a local `.env` file (not committed) if you need to automate
+  authentication.
+- Run `python -m compileall .` before committing changes to ensure syntax
+  correctness.
+
+## License
+
+This repository is provided for academic research purposes. Ensure your use of
+Freelancer.com data complies with their policies and with your institution's
+ethics requirements.

--- a/freelancer_research/__init__.py
+++ b/freelancer_research/__init__.py
@@ -1,0 +1,3 @@
+"""Top-level package for Freelancer welfare research scraping tools."""
+
+from .scraper import FreelancerScraper, ProjectSummary, BidRecord, EmployerProfile  # noqa: F401

--- a/freelancer_research/cli.py
+++ b/freelancer_research/cli.py
@@ -1,0 +1,143 @@
+"""Command line interface for the Freelancer.com welfare data scraper."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from .exporters import export_bids_to_csv, export_projects_to_csv
+from .scraper import FreelancerScraper, ProjectSummary
+
+
+def _load_terms(search_terms: Sequence[str], search_file: Path | None) -> List[str]:
+    terms: List[str] = list(search_terms)
+    if search_file and search_file.exists():
+        with search_file.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                cleaned = line.strip()
+                if cleaned and not cleaned.startswith("#"):
+                    terms.append(cleaned)
+    unique_terms = list(dict.fromkeys(term.strip() for term in terms if term.strip()))
+    return unique_terms
+
+
+def _export_data(projects: Iterable[ProjectSummary], args: argparse.Namespace) -> None:
+    output_path: Path = args.output
+    if output_path.suffix.lower() == ".json":
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as fh:
+            json.dump([project.to_dict() for project in projects], fh, indent=2)
+    elif output_path.suffix.lower() == ".csv":
+        export_projects_to_csv(projects, output_path)
+    else:
+        raise ValueError("Unsupported output format. Use .json or .csv")
+
+    if args.bids_output:
+        export_bids_to_csv(projects, args.bids_output)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Collect project and bid data from Freelancer.com for welfare "
+            "economics research questions such as access cliffs or winner's curse."
+        )
+    )
+    parser.add_argument(
+        "--search",
+        action="append",
+        dest="search_terms",
+        default=[],
+        help="Keyword to search for. Provide multiple times for multiple queries.",
+    )
+    parser.add_argument(
+        "--search-file",
+        type=Path,
+        help="Optional file containing one search term per line.",
+    )
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=1,
+        help="Number of result pages to fetch per search term.",
+    )
+    parser.add_argument(
+        "--results-per-page",
+        type=int,
+        default=20,
+        help="How many projects to request per page (Freelancer supports up to ~100).",
+    )
+    parser.add_argument(
+        "--include-bids",
+        action="store_true",
+        help="Follow each project link and capture individual bid information.",
+    )
+    parser.add_argument(
+        "--max-bids",
+        type=int,
+        help="Maximum number of bids to retain per project.",
+    )
+    parser.add_argument(
+        "--headless",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Run the browser in headless mode (default: True).",
+    )
+    parser.add_argument(
+        "--email",
+        help=(
+            "Freelancer account email. Optional, but helpful for scraping "
+            "bidder details that are behind authentication."
+        ),
+    )
+    parser.add_argument(
+        "--password",
+        help="Freelancer account password. If omitted the FREELANCER_PASSWORD env var is used.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/freelancer_projects.json"),
+        help="Destination file (.json or .csv) for the project summaries.",
+    )
+    parser.add_argument(
+        "--bids-output",
+        type=Path,
+        help="Optional CSV file to receive bid level data when --include-bids is used.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Seed for the random delay generator to ensure reproducible pacing.",
+    )
+
+    args = parser.parse_args(argv)
+    search_terms = _load_terms(args.search_terms, args.search_file)
+    if not search_terms:
+        parser.error("Provide at least one --search term or a --search-file.")
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    email = args.email or os.getenv("FREELANCER_EMAIL")
+    password = args.password or os.getenv("FREELANCER_PASSWORD")
+
+    with FreelancerScraper(headless=args.headless) as scraper:
+        if email and password:
+            scraper.login(email, password)
+        projects = scraper.collect_projects(
+            search_terms,
+            pages_per_term=args.pages,
+            results_per_page=args.results_per_page,
+            include_bids=args.include_bids,
+            max_bids=args.max_bids,
+        )
+    _export_data(projects, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/freelancer_research/exporters.py
+++ b/freelancer_research/exporters.py
@@ -1,0 +1,100 @@
+"""Utilities for exporting scraped Freelancer data to common formats."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Iterable, List
+
+from .scraper import BidRecord, ProjectSummary
+
+
+def export_projects_to_csv(projects: Iterable[ProjectSummary], output_path: Path) -> None:
+    """Write high-level project summaries to a CSV file."""
+
+    fieldnames = [
+        "project_id",
+        "title",
+        "url",
+        "description",
+        "budget_min",
+        "budget_max",
+        "currency_code",
+        "currency_symbol",
+        "bids_count",
+        "average_bid",
+        "posted_time",
+        "project_type",
+        "skills",
+        "employer_name",
+        "employer_rating",
+        "employer_review_count",
+        "employer_location",
+    ]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for project in projects:
+            writer.writerow(
+                {
+                    "project_id": project.project_id,
+                    "title": project.title,
+                    "url": project.url,
+                    "description": project.description,
+                    "budget_min": project.budget_min,
+                    "budget_max": project.budget_max,
+                    "currency_code": project.currency_code,
+                    "currency_symbol": project.currency_symbol,
+                    "bids_count": project.bids_count,
+                    "average_bid": project.average_bid,
+                    "posted_time": project.posted_time,
+                    "project_type": project.project_type,
+                    "skills": "|".join(project.skills),
+                    "employer_name": project.employer.name,
+                    "employer_rating": project.employer.rating,
+                    "employer_review_count": project.employer.review_count,
+                    "employer_location": project.employer.location,
+                }
+            )
+
+
+def export_bids_to_csv(projects: Iterable[ProjectSummary], output_path: Path) -> None:
+    """Write all captured bids to a CSV file."""
+
+    fieldnames = [
+        "project_id",
+        "username",
+        "rating",
+        "review_count",
+        "amount",
+        "currency_code",
+        "delivery_days",
+        "status",
+    ]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for project in projects:
+            for bid in _flatten_bids(project.project_id, project.bids):
+                writer.writerow(bid)
+
+
+def _flatten_bids(project_id: str, bids: List[BidRecord]):
+    for bid in bids:
+        yield {
+            "project_id": project_id,
+            "username": bid.username,
+            "rating": bid.rating,
+            "review_count": bid.review_count,
+            "amount": bid.amount,
+            "currency_code": bid.currency_code,
+            "delivery_days": bid.delivery_days,
+            "status": bid.status,
+        }
+
+
+__all__ = ["export_projects_to_csv", "export_bids_to_csv"]

--- a/freelancer_research/scraper.py
+++ b/freelancer_research/scraper.py
@@ -1,0 +1,533 @@
+"""Utilities for collecting project and bidding data from Freelancer.com.
+
+The module is intentionally written to support welfare-oriented empirical
+research questions.  It uses Selenium to drive a real browser session and then
+extracts structured project and bid information from the rendered DOM or
+bootstrapped JSON payloads exposed by the site.  The selectors prefer semantic
+attributes (``data-test`` etc.) and fall back to heuristic extraction so that
+slight front-end changes require minimal updates.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from selenium import webdriver
+from selenium.common.exceptions import (  # type: ignore
+    TimeoutException,
+    WebDriverException,
+)
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.chrome.service import Service as ChromeService
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+try:
+    from webdriver_manager.chrome import ChromeDriverManager
+except ImportError as exc:  # pragma: no cover - guidance for missing dependency
+    raise ImportError(
+        "webdriver-manager is required to automatically provision the Chrome "
+        "driver.  Install it via `pip install webdriver-manager`."
+    ) from exc
+
+
+BUDGET_RANGE_RE = re.compile(r"([\\d,.]+)")
+CURRENCY_RE = re.compile(r"([A-Z]{3})")
+PROJECT_ID_RE = re.compile(r"(?P<project_id>\\d{5,})")
+BID_COUNT_RE = re.compile(r"(\\d+)")
+
+
+@dataclass
+class EmployerProfile:
+    """Summary information about the employer who posted a project."""
+
+    name: Optional[str] = None
+    rating: Optional[float] = None
+    review_count: Optional[int] = None
+    location: Optional[str] = None
+
+
+@dataclass
+class BidRecord:
+    """Represents a single bid placed on a Freelancer project."""
+
+    username: Optional[str] = None
+    rating: Optional[float] = None
+    review_count: Optional[int] = None
+    amount: Optional[float] = None
+    currency_code: Optional[str] = None
+    delivery_days: Optional[int] = None
+    status: Optional[str] = None
+
+
+@dataclass
+class ProjectSummary:
+    """Structured representation of a Freelancer project listing."""
+
+    project_id: str
+    title: str
+    url: str
+    description: Optional[str] = None
+    budget_min: Optional[float] = None
+    budget_max: Optional[float] = None
+    currency_code: Optional[str] = None
+    currency_symbol: Optional[str] = None
+    bids_count: Optional[int] = None
+    average_bid: Optional[float] = None
+    posted_time: Optional[str] = None
+    project_type: Optional[str] = None
+    skills: List[str] = field(default_factory=list)
+    employer: EmployerProfile = field(default_factory=EmployerProfile)
+    raw_attributes: Dict[str, Any] = field(default_factory=dict)
+    bids: List[BidRecord] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the dataclass (including nested dataclasses) to a dictionary."""
+
+        payload = asdict(self)
+        payload["employer"] = asdict(self.employer)
+        payload["bids"] = [asdict(bid) for bid in self.bids]
+        return payload
+
+
+class FreelancerScraper:
+    """High-level helper that orchestrates Selenium driven scraping sessions."""
+
+    BASE_URL = "https://www.freelancer.com"
+    JOB_SEARCH_PATH = "/jobs/"
+
+    def __init__(
+        self,
+        *,
+        headless: bool = True,
+        driver: Optional[WebDriver] = None,
+        timeout: int = 20,
+        min_delay: float = 1.0,
+        max_delay: float = 3.0,
+    ) -> None:
+        self._driver = driver
+        self.timeout = timeout
+        self.min_delay = min_delay
+        self.max_delay = max_delay
+        self.headless = headless
+
+    # ------------------------------------------------------------------
+    # Driver / context management
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "FreelancerScraper":
+        if self._driver is None:
+            self._driver = self._build_driver()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+    @property
+    def driver(self) -> WebDriver:
+        if self._driver is None:
+            self._driver = self._build_driver()
+        return self._driver
+
+    def close(self) -> None:
+        if self._driver is not None:
+            try:
+                self._driver.quit()
+            except WebDriverException:
+                pass
+            finally:
+                self._driver = None
+
+    def _build_driver(self) -> WebDriver:
+        options = ChromeOptions()
+        if self.headless:
+            options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--window-size=1920,1080")
+        options.add_argument("--disable-dev-shm-usage")
+        options.add_argument("--lang=en-US")
+        service = ChromeService(executable_path=ChromeDriverManager().install())
+        return webdriver.Chrome(service=service, options=options)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def login(self, email: str, password: str) -> None:
+        """Login to Freelancer using provided credentials.
+
+        Parameters
+        ----------
+        email:
+            Account email/username.
+        password:
+            Account password.
+        """
+
+        self.driver.get(f"{self.BASE_URL}/login")
+        wait = WebDriverWait(self.driver, self.timeout)
+        email_field = wait.until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "input[type='email']"))
+        )
+        email_field.clear()
+        email_field.send_keys(email)
+
+        password_field = wait.until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "input[type='password']"))
+        )
+        password_field.clear()
+        password_field.send_keys(password)
+
+        submit_button = self.driver.find_element(By.CSS_SELECTOR, "button[type='submit']")
+        submit_button.click()
+
+        wait.until(EC.url_contains("/dashboard"))
+        self._human_delay()
+
+    def collect_projects(
+        self,
+        search_terms: Sequence[str],
+        *,
+        pages_per_term: int = 1,
+        results_per_page: int = 20,
+        include_bids: bool = False,
+        max_bids: Optional[int] = None,
+    ) -> List[ProjectSummary]:
+        """Collect project listings for the supplied search terms.
+
+        Parameters
+        ----------
+        search_terms:
+            Keywords to query via Freelancer's job search.  Each term is scraped
+            separately.  The results are concatenated in the order provided.
+        pages_per_term:
+            Number of pages to collect for each query.
+        results_per_page:
+            Pagination parameter used to request more (or fewer) results per
+            page.  Values between 20 and 100 are a good compromise between
+            payload size and request count.
+        include_bids:
+            When ``True`` the scraper opens each project detail page and
+            attempts to capture individual bid data, including bid amount and
+            bidder reputation metrics.  This significantly slows down the
+            process but is required for questions related to winner's curse.
+        max_bids:
+            Optional upper bound for the number of bids captured per project.
+        """
+
+        projects: List[ProjectSummary] = []
+        for term in search_terms:
+            for page_index in range(pages_per_term):
+                offset = page_index * results_per_page
+                page_url = self._build_search_url(term, results_per_page, offset)
+                try:
+                    summaries = self._collect_search_page(page_url)
+                except TimeoutException:
+                    continue
+
+                for summary in summaries:
+                    if include_bids:
+                        try:
+                            bid_records = self._collect_bids(summary.url, max_bids)
+                            summary.bids = bid_records
+                            summary.bids_count = summary.bids_count or len(bid_records)
+                        except TimeoutException:
+                            pass
+                        finally:
+                            self._close_extra_tabs()
+                    projects.append(summary)
+                self._human_delay()
+        return projects
+
+    def dump_to_json(self, projects: Iterable[ProjectSummary], output_path: Path) -> None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as fh:
+            json.dump([project.to_dict() for project in projects], fh, indent=2)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _human_delay(self) -> None:
+        time.sleep(random.uniform(self.min_delay, self.max_delay))
+
+    def _build_search_url(self, search_term: str, results: int, offset: int) -> str:
+        from urllib.parse import quote_plus
+
+        keyword = quote_plus(search_term)
+        return (
+            f"{self.BASE_URL}{self.JOB_SEARCH_PATH}?keyword={keyword}&results={results}&offset={offset}"
+        )
+
+    def _wait_for_project_cards(self) -> None:
+        wait = WebDriverWait(self.driver, self.timeout)
+        wait.until(
+            lambda driver: driver.execute_script(
+                "return document.querySelectorAll('app-project-card, "
+                "[data-test=\'project-card\'], .ProjectCard, li[data-card-type=\'project\']').length"
+            )
+        )
+
+    def _collect_search_page(self, url: str) -> List[ProjectSummary]:
+        self.driver.get(url)
+        self._wait_for_project_cards()
+        project_payloads = self.driver.execute_script(
+            """
+            const cardSelector = 'app-project-card, [data-test="project-card"], .ProjectCard, li[data-card-type="project"]';
+            return Array.from(document.querySelectorAll(cardSelector)).map(card => {
+                const link = card.querySelector('a[href*="/projects/"]');
+                const budget = card.querySelector('[data-test="project-card-budget"], .ProjectCard-budget, .JobSearchCard-primary-bid span');
+                const bids = card.querySelector('[data-test="project-card-bids"], .ProjectCard-bids, .JobSearchCard-primary-bid strong');
+                const employer = card.querySelector('[data-test="project-card-employer"], .ProjectCard-byline, .EmployerInfo');
+                const description = card.querySelector('[data-test="project-card-description"], .ProjectCard-description, .JobSearchCard-secondary-description');
+                const meta = card.querySelector('[data-test="project-card-meta"], .ProjectCard-meta, .JobSearchCard-primary-info');
+                const avgBid = card.querySelector('[data-test="project-card-avg-bid"], .ProjectCard-average, .JobSearchCard-average-bid strong');
+                const skills = Array.from(card.querySelectorAll('a[href*="/jobs/"], [data-test="project-skill"], .ProjectCard-skill')).map(el => el.textContent.trim());
+                return {
+                    title: link ? link.textContent.trim() : null,
+                    url: link ? link.href : null,
+                    budget: budget ? budget.textContent.trim() : null,
+                    bidsText: bids ? bids.textContent.trim() : null,
+                    employer: employer ? employer.textContent.trim() : null,
+                    description: description ? description.textContent.trim() : null,
+                    meta: meta ? meta.textContent.trim() : null,
+                    avgBid: avgBid ? avgBid.textContent.trim() : null,
+                    skills: skills,
+                };
+            });
+            """
+        )
+
+        summaries: List[ProjectSummary] = []
+        for payload in project_payloads:
+            summary = self._payload_to_summary(payload)
+            if summary is not None:
+                summaries.append(summary)
+        return summaries
+
+    def _payload_to_summary(self, payload: Dict[str, Any]) -> Optional[ProjectSummary]:
+        url = payload.get("url")
+        title = payload.get("title")
+        if not url or not title:
+            return None
+
+        project_id_match = PROJECT_ID_RE.search(url)
+        if not project_id_match:
+            return None
+
+        budget_min, budget_max, symbol, currency_code = self._parse_budget(payload.get("budget"))
+        avg_bid_val, avg_bid_currency = self._parse_amount(payload.get("avgBid"))
+        bids_count = self._parse_bids_count(payload.get("bidsText"))
+        employer_profile = self._parse_employer(payload.get("employer"))
+        summary = ProjectSummary(
+            project_id=project_id_match.group("project_id"),
+            title=title,
+            url=url,
+            description=payload.get("description"),
+            budget_min=budget_min,
+            budget_max=budget_max,
+            currency_code=currency_code or avg_bid_currency,
+            currency_symbol=symbol,
+            bids_count=bids_count,
+            average_bid=avg_bid_val,
+            posted_time=payload.get("meta"),
+            skills=[skill for skill in (payload.get("skills") or []) if skill],
+            employer=employer_profile,
+            raw_attributes={key: val for key, val in payload.items() if key not in {"skills"}},
+        )
+        return summary
+
+    def _parse_budget(
+        self, budget_text: Optional[str]
+    ) -> (Optional[float], Optional[float], Optional[str], Optional[str]):
+        if not budget_text:
+            return None, None, None, None
+
+        cleaned = budget_text.replace("Budget", "").replace("Avg Bid", "").strip()
+        currency_symbol = None
+        if cleaned and not cleaned[0].isdigit():
+            currency_symbol = cleaned[0]
+        numbers = [self._to_float(value) for value in BUDGET_RANGE_RE.findall(cleaned)]
+        currency_code_match = CURRENCY_RE.search(cleaned)
+        currency_code = currency_code_match.group(1) if currency_code_match else None
+        if not numbers:
+            return None, None, currency_symbol, currency_code
+        if len(numbers) == 1:
+            return numbers[0], numbers[0], currency_symbol, currency_code
+        return numbers[0], numbers[1], currency_symbol, currency_code
+
+    def _parse_amount(self, amount_text: Optional[str]) -> (Optional[float], Optional[str]):
+        if not amount_text:
+            return None, None
+        numbers = [self._to_float(value) for value in BUDGET_RANGE_RE.findall(amount_text)]
+        currency_code_match = CURRENCY_RE.search(amount_text)
+        currency_code = currency_code_match.group(1) if currency_code_match else None
+        return (numbers[0] if numbers else None, currency_code)
+
+    def _parse_bids_count(self, bids_text: Optional[str]) -> Optional[int]:
+        if not bids_text:
+            return None
+        match = BID_COUNT_RE.search(bids_text.replace(",", ""))
+        return int(match.group(1)) if match else None
+
+    def _parse_employer(self, employer_text: Optional[str]) -> EmployerProfile:
+        if not employer_text:
+            return EmployerProfile()
+
+        rating_match = re.search(r"([0-9]+(?:\\.[0-9]+)?)\s*/\s*5", employer_text)
+        review_match = re.search(r"(\\d+)\s*(?:reviews|Review|Ratings?)", employer_text, re.IGNORECASE)
+        name = employer_text.split("\n")[0].strip()
+        location_match = re.search(r"from\s+(.+)", employer_text, re.IGNORECASE)
+        return EmployerProfile(
+            name=name or None,
+            rating=float(rating_match.group(1)) if rating_match else None,
+            review_count=int(review_match.group(1)) if review_match else None,
+            location=location_match.group(1).strip() if location_match else None,
+        )
+
+    def _collect_bids(self, project_url: str, max_bids: Optional[int]) -> List[BidRecord]:
+        self._open_in_new_tab(project_url)
+        wait = WebDriverWait(self.driver, self.timeout)
+        wait.until(lambda driver: driver.execute_script("return document.readyState") == "complete")
+        data_blobs = self.driver.execute_script(
+            """
+            const results = [];
+            if (window.__NUXT__) { results.push(JSON.stringify(window.__NUXT__)); }
+            if (window.__INITIAL_STATE__) { results.push(JSON.stringify(window.__INITIAL_STATE__)); }
+            if (window.__APP_INITIAL_STATE__) { results.push(JSON.stringify(window.__APP_INITIAL_STATE__)); }
+            const jsonScripts = Array.from(document.querySelectorAll('script[type="application/json"]'));
+            jsonScripts.forEach(script => results.push(script.textContent));
+            const nextData = document.querySelector('#__NEXT_DATA__');
+            if (nextData) { results.push(nextData.textContent); }
+            return results;
+            """
+        )
+
+        for blob in data_blobs:
+            try:
+                data = json.loads(blob)
+            except json.JSONDecodeError:
+                continue
+            bid_records = self._extract_bids_from_blob(data, max_bids)
+            if bid_records:
+                return bid_records
+        return []
+
+    def _extract_bids_from_blob(self, data: Any, max_bids: Optional[int]) -> List[BidRecord]:
+        bids: List[BidRecord] = []
+
+        def traverse(node: Any) -> None:
+            if isinstance(node, dict):
+                if {"bids", "project"}.issubset(node.keys()):
+                    bids.extend(self._convert_bid_payloads(node["bids"], max_bids))
+                elif "bids" in node and isinstance(node["bids"], list):
+                    bids.extend(self._convert_bid_payloads(node["bids"], max_bids))
+                for value in node.values():
+                    traverse(value)
+            elif isinstance(node, list):
+                for value in node:
+                    traverse(value)
+
+        traverse(data)
+        return bids[:max_bids] if max_bids else bids
+
+    def _convert_bid_payloads(
+        self, payloads: Sequence[Any], max_bids: Optional[int]
+    ) -> List[BidRecord]:
+        bid_records: List[BidRecord] = []
+        for payload in payloads[: max_bids or None]:
+            if not isinstance(payload, dict):
+                continue
+            amount = payload.get("amount") or payload.get("bid_amount")
+            currency = None
+            if isinstance(amount, dict):
+                currency = amount.get("currency") or amount.get("currency_code")
+                value = amount.get("amount") or amount.get("value")
+            else:
+                value = amount
+            bidder = payload.get("bidder") or payload.get("user") or {}
+            rating_info = bidder.get("reputation") or payload.get("reputation") or {}
+            bid_record = BidRecord(
+                username=bidder.get("username"),
+                rating=self._safe_float(rating_info.get("overall")),
+                review_count=self._safe_int(rating_info.get("review_count")),
+                amount=self._safe_float(value),
+                currency_code=currency,
+                delivery_days=self._safe_int(payload.get("period") or payload.get("delivery_time")),
+                status=payload.get("status"),
+            )
+            bid_records.append(bid_record)
+        return bid_records
+
+    def _open_in_new_tab(self, url: str) -> None:
+        self.driver.execute_script("window.open(arguments[0], '_blank');", url)
+        self.driver.switch_to.window(self.driver.window_handles[-1])
+        self._human_delay()
+
+    def _close_extra_tabs(self) -> None:
+        while len(self.driver.window_handles) > 1:
+            handle = self.driver.window_handles[-1]
+            self.driver.switch_to.window(handle)
+            self.driver.close()
+        self.driver.switch_to.window(self.driver.window_handles[0])
+
+    def _safe_float(self, value: Any) -> Optional[float]:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _safe_int(self, value: Any) -> Optional[int]:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _to_float(self, value: str) -> Optional[float]:
+        try:
+            return float(value.replace(",", ""))
+        except ValueError:
+            return None
+
+
+def default_scraper_from_env() -> FreelancerScraper:
+    """Factory that optionally performs a login using environment variables."""
+
+    scraper = FreelancerScraper()
+    email = os.getenv("FREELANCER_EMAIL")
+    password = os.getenv("FREELANCER_PASSWORD")
+    if email and password:
+        with scraper:
+            scraper.login(email, password)
+    return scraper
+
+
+def save_projects_to_disk(
+    projects: Iterable[ProjectSummary],
+    output: Path,
+) -> None:
+    """Persist collected project data to JSON."""
+
+    scraper = FreelancerScraper()
+    scraper.dump_to_json(projects, output)
+
+
+__all__ = [
+    "FreelancerScraper",
+    "ProjectSummary",
+    "BidRecord",
+    "EmployerProfile",
+    "default_scraper_from_env",
+    "save_projects_to_disk",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+selenium>=4.11,<5
+webdriver-manager>=4.0,<5


### PR DESCRIPTION
## Summary
- add a Selenium-backed `FreelancerScraper` capable of collecting project and bid data for welfare studies
- provide a CLI wrapper plus CSV/JSON export helpers for downstream analysis
- document installation, usage, and ethical considerations, and record Python dependencies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d4026246cc8320913e018bbb2842a7