### PR TITLE
Add longitudinal observation support to scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ entrants, or how employer reputation interacts with bidding behaviour.
   which is essential for studying phenomena like the winner's curse.
 - **Flexible exports** – Save results as JSON or CSV files for downstream
   analysis in Python, R, or statistical packages.
+- **Longitudinal observations** – Stamp each scrape with UTC timestamps and an
+  optional run identifier so repeated captures can be stitched into time-series
+  panels.
 - **Polite defaults** – Headless browsing with randomised delays, plus hooks to
   authenticate via environment variables when deeper data requires login.
 
@@ -47,7 +50,9 @@ python -m freelancer_research.cli \
   --results-per-page 50 \
   --include-bids \
   --max-bids 40 \
-  --output data/projects.json \
+  --run-id "$(date -u +"%Y%m%dT%H%M%SZ")" \
+  --append \
+  --output data/projects.jsonl \
   --bids-output data/bids.csv
 ```
 
@@ -67,12 +72,17 @@ python -m freelancer_research.cli --search "machine learning" --include-bids
 
 - **Project summaries** include the project id, title, description, budget
   bounds, bid counts, employer reputation snippets, and detected skills. When
-  exported to CSV, skills are pipe-delimited for easier parsing.
+  exported to CSV, skills are pipe-delimited for easier parsing. Additional
+  metadata includes an `observed_at` timestamp, the optional `observation_run_id`
+  set via `--run-id`, and a `status_events` array capturing observed statuses
+  and bid counts over time.
 - **Bid level records** (optional) contain project id, bidder username,
   reputation metrics, offered amount, currency code, stated delivery days, and
-  status. These fields are sufficient to construct panels for welfare analyses
-  such as bid dispersion, newcomer versus incumbent success, or estimating
-  access cliffs.
+  status. They are enriched with `observed_at` timestamps and the originating
+  run identifier, making it easier to align bid changes with project level
+  observations. These fields are sufficient to construct panels for welfare
+  analyses such as bid dispersion, newcomer versus incumbent success, or
+  estimating access cliffs.
 
 ### Research Considerations
 
@@ -92,6 +102,77 @@ python -m freelancer_research.cli --search "machine learning" --include-bids
   authentication.
 - Run `python -m compileall .` before committing changes to ensure syntax
   correctness.
+
+## Building a Longitudinal Dataset
+
+Recurring executions let you monitor how projects evolve (status changes,
+incoming bids, budget adjustments). Two common scheduling approaches are shown
+below. Replace the sample search term and output paths as needed.
+
+### Cron
+
+Add an entry with `crontab -e` to run the scraper every hour, appending to JSONL
+and CSV outputs while stamping each run with a unique identifier:
+
+```
+0 * * * * cd /path/to/Freelancer-Research && \
+  /usr/bin/env python -m freelancer_research.cli \
+    --search "data entry" \
+    --pages 2 \
+    --results-per-page 50 \
+    --include-bids \
+    --run-id "$(date -u +\"%Y%m%dT%H%M%SZ\")" \
+    --append \
+    --output data/projects.jsonl \
+    --bids-output data/bids.csv >> logs/scraper.log 2>&1
+```
+
+### systemd timers
+
+Create a service unit (e.g. `/etc/systemd/system/freelancer-scraper.service`):
+
+```
+[Unit]
+Description=Freelancer.com longitudinal scraper
+
+[Service]
+Type=oneshot
+WorkingDirectory=/path/to/Freelancer-Research
+ExecStart=/usr/bin/env python -m freelancer_research.cli \
+  --search "data entry" \
+  --pages 2 \
+  --include-bids \
+  --results-per-page 50 \
+  --run-id "$(date -u +\"%Y%m%dT%H%M%SZ\")" \
+  --append \
+  --output data/projects.jsonl \
+  --bids-output data/bids.csv
+```
+
+Then define the timer (`/etc/systemd/system/freelancer-scraper.timer`):
+
+```
+[Unit]
+Description=Run Freelancer scraper hourly
+
+[Timer]
+OnBootSec=5m
+OnUnitActiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and start the timer with:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now freelancer-scraper.timer
+```
+
+The `Persistent=true` flag ensures missed runs execute on boot, keeping your
+time-series dataset up to date.
 
 ## License
 

--- a/freelancer_research/cli.py
+++ b/freelancer_research/cli.py
@@ -26,18 +26,36 @@ def _load_terms(search_terms: Sequence[str], search_file: Path | None) -> List[s
 
 
 def _export_data(projects: Iterable[ProjectSummary], args: argparse.Namespace) -> None:
+    project_list = list(projects)
     output_path: Path = args.output
+    append = bool(args.append)
     if output_path.suffix.lower() == ".json":
         output_path.parent.mkdir(parents=True, exist_ok=True)
+        existing: list[dict] = []
+        if append and output_path.exists():
+            try:
+                with output_path.open("r", encoding="utf-8") as fh:
+                    loaded = json.load(fh)
+                    if isinstance(loaded, list):
+                        existing = loaded
+            except json.JSONDecodeError:
+                existing = []
         with output_path.open("w", encoding="utf-8") as fh:
-            json.dump([project.to_dict() for project in projects], fh, indent=2)
+            json.dump(existing + [project.to_dict() for project in project_list], fh, indent=2)
+    elif output_path.suffix.lower() == ".jsonl":
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        mode = "a" if append or output_path.exists() else "w"
+        with output_path.open(mode, encoding="utf-8") as fh:
+            for project in project_list:
+                fh.write(json.dumps(project.to_dict()))
+                fh.write("\n")
     elif output_path.suffix.lower() == ".csv":
-        export_projects_to_csv(projects, output_path)
+        export_projects_to_csv(project_list, output_path, append=append)
     else:
-        raise ValueError("Unsupported output format. Use .json or .csv")
+        raise ValueError("Unsupported output format. Use .json, .jsonl, or .csv")
 
     if args.bids_output:
-        export_bids_to_csv(projects, args.bids_output)
+        export_bids_to_csv(project_list, args.bids_output, append=append)
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -110,6 +128,15 @@ def main(argv: Sequence[str] | None = None) -> None:
         help="Optional CSV file to receive bid level data when --include-bids is used.",
     )
     parser.add_argument(
+        "--append",
+        action="store_true",
+        help="Append results to existing outputs instead of overwriting them.",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="Identifier for the scrape run to help correlate longitudinal exports.",
+    )
+    parser.add_argument(
         "--seed",
         type=int,
         help="Seed for the random delay generator to ensure reproducible pacing.",
@@ -135,6 +162,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             results_per_page=args.results_per_page,
             include_bids=args.include_bids,
             max_bids=args.max_bids,
+            observation_run_id=args.run_id,
         )
     _export_data(projects, args)
 

--- a/freelancer_research/exporters.py
+++ b/freelancer_research/exporters.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 import csv
+import json
+from dataclasses import asdict
 from pathlib import Path
 from typing import Iterable, List
 
 from .scraper import BidRecord, ProjectSummary
 
 
-def export_projects_to_csv(projects: Iterable[ProjectSummary], output_path: Path) -> None:
+def export_projects_to_csv(
+    projects: Iterable[ProjectSummary],
+    output_path: Path,
+    *,
+    append: bool = False,
+) -> None:
     """Write high-level project summaries to a CSV file."""
 
     fieldnames = [
@@ -30,12 +37,20 @@ def export_projects_to_csv(projects: Iterable[ProjectSummary], output_path: Path
         "employer_rating",
         "employer_review_count",
         "employer_location",
+        "observed_at",
+        "observation_run_id",
+        "status_events",
     ]
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8", newline="") as csvfile:
+    mode = "a" if append and output_path.exists() else "w"
+    write_header = True
+    if mode == "a" and output_path.exists():
+        write_header = output_path.stat().st_size == 0
+    with output_path.open(mode, encoding="utf-8", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
+        if write_header:
+            writer.writeheader()
         for project in projects:
             writer.writerow(
                 {
@@ -56,11 +71,22 @@ def export_projects_to_csv(projects: Iterable[ProjectSummary], output_path: Path
                     "employer_rating": project.employer.rating,
                     "employer_review_count": project.employer.review_count,
                     "employer_location": project.employer.location,
+                    "observed_at": project.observed_at,
+                    "observation_run_id": project.observation_run_id,
+                    "status_events": json.dumps(
+                        [asdict(event) for event in project.status_events],
+                        ensure_ascii=False,
+                    ),
                 }
             )
 
 
-def export_bids_to_csv(projects: Iterable[ProjectSummary], output_path: Path) -> None:
+def export_bids_to_csv(
+    projects: Iterable[ProjectSummary],
+    output_path: Path,
+    *,
+    append: bool = False,
+) -> None:
     """Write all captured bids to a CSV file."""
 
     fieldnames = [
@@ -72,12 +98,19 @@ def export_bids_to_csv(projects: Iterable[ProjectSummary], output_path: Path) ->
         "currency_code",
         "delivery_days",
         "status",
+        "observed_at",
+        "observation_run_id",
     ]
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8", newline="") as csvfile:
+    mode = "a" if append and output_path.exists() else "w"
+    write_header = True
+    if mode == "a" and output_path.exists():
+        write_header = output_path.stat().st_size == 0
+    with output_path.open(mode, encoding="utf-8", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
+        if write_header:
+            writer.writeheader()
         for project in projects:
             for bid in _flatten_bids(project.project_id, project.bids):
                 writer.writerow(bid)
@@ -94,6 +127,8 @@ def _flatten_bids(project_id: str, bids: List[BidRecord]):
             "currency_code": bid.currency_code,
             "delivery_days": bid.delivery_days,
             "status": bid.status,
+            "observed_at": bid.observed_at,
+            "observation_run_id": bid.observation_run_id,
         }
 
 

--- a/freelancer_research/scraper.py
+++ b/freelancer_research/scraper.py
@@ -16,6 +16,7 @@ import random
 import re
 import time
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
@@ -46,6 +47,12 @@ PROJECT_ID_RE = re.compile(r"(?P<project_id>\\d{5,})")
 BID_COUNT_RE = re.compile(r"(\\d+)")
 
 
+def _utc_now_iso() -> str:
+    """Return a UTC timestamp (with trailing Z) for serialization."""
+
+    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
 @dataclass
 class EmployerProfile:
     """Summary information about the employer who posted a project."""
@@ -67,6 +74,19 @@ class BidRecord:
     currency_code: Optional[str] = None
     delivery_days: Optional[int] = None
     status: Optional[str] = None
+    observed_at: str = field(default_factory=_utc_now_iso)
+    observation_run_id: Optional[str] = None
+
+
+@dataclass
+class StatusEvent:
+    """Represents an observation of the project's lifecycle state."""
+
+    status: Optional[str] = None
+    observed_at: str = field(default_factory=_utc_now_iso)
+    run_id: Optional[str] = None
+    bids_count: Optional[int] = None
+    average_bid: Optional[float] = None
 
 
 @dataclass
@@ -89,6 +109,9 @@ class ProjectSummary:
     employer: EmployerProfile = field(default_factory=EmployerProfile)
     raw_attributes: Dict[str, Any] = field(default_factory=dict)
     bids: List[BidRecord] = field(default_factory=list)
+    observed_at: str = field(default_factory=_utc_now_iso)
+    observation_run_id: Optional[str] = None
+    status_events: List[StatusEvent] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert the dataclass (including nested dataclasses) to a dictionary."""
@@ -96,6 +119,7 @@ class ProjectSummary:
         payload = asdict(self)
         payload["employer"] = asdict(self.employer)
         payload["bids"] = [asdict(bid) for bid in self.bids]
+        payload["status_events"] = [asdict(event) for event in self.status_events]
         return payload
 
 
@@ -200,6 +224,7 @@ class FreelancerScraper:
         results_per_page: int = 20,
         include_bids: bool = False,
         max_bids: Optional[int] = None,
+        observation_run_id: Optional[str] = None,
     ) -> List[ProjectSummary]:
         """Collect project listings for the supplied search terms.
 
@@ -234,11 +259,29 @@ class FreelancerScraper:
                     continue
 
                 for summary in summaries:
+                    observed_at = _utc_now_iso()
+                    summary.observed_at = observed_at
+                    summary.observation_run_id = observation_run_id
+                    status_event = StatusEvent(
+                        status=summary.raw_attributes.get("status")
+                        or summary.project_type,
+                        observed_at=observed_at,
+                        run_id=observation_run_id,
+                        bids_count=summary.bids_count,
+                        average_bid=summary.average_bid,
+                    )
+                    summary.status_events.append(status_event)
                     if include_bids:
                         try:
-                            bid_records = self._collect_bids(summary.url, max_bids)
+                            bid_records = self._collect_bids(
+                                summary.url,
+                                max_bids,
+                                observed_at=observed_at,
+                                observation_run_id=observation_run_id,
+                            )
                             summary.bids = bid_records
                             summary.bids_count = summary.bids_count or len(bid_records)
+                            status_event.bids_count = summary.bids_count
                         except TimeoutException:
                             pass
                         finally:
@@ -247,10 +290,26 @@ class FreelancerScraper:
                 self._human_delay()
         return projects
 
-    def dump_to_json(self, projects: Iterable[ProjectSummary], output_path: Path) -> None:
+    def dump_to_json(
+        self,
+        projects: Iterable[ProjectSummary],
+        output_path: Path,
+        *,
+        append: bool = False,
+    ) -> None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
+        new_records = [project.to_dict() for project in projects]
+        existing: List[Dict[str, Any]] = []
+        if append and output_path.exists():
+            try:
+                with output_path.open("r", encoding="utf-8") as fh:
+                    loaded = json.load(fh)
+                    if isinstance(loaded, list):
+                        existing = loaded
+            except json.JSONDecodeError:
+                existing = []
         with output_path.open("w", encoding="utf-8") as fh:
-            json.dump([project.to_dict() for project in projects], fh, indent=2)
+            json.dump(existing + new_records, fh, indent=2)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -392,7 +451,14 @@ class FreelancerScraper:
             location=location_match.group(1).strip() if location_match else None,
         )
 
-    def _collect_bids(self, project_url: str, max_bids: Optional[int]) -> List[BidRecord]:
+    def _collect_bids(
+        self,
+        project_url: str,
+        max_bids: Optional[int],
+        *,
+        observed_at: Optional[str] = None,
+        observation_run_id: Optional[str] = None,
+    ) -> List[BidRecord]:
         self._open_in_new_tab(project_url)
         wait = WebDriverWait(self.driver, self.timeout)
         wait.until(lambda driver: driver.execute_script("return document.readyState") == "complete")
@@ -415,20 +481,46 @@ class FreelancerScraper:
                 data = json.loads(blob)
             except json.JSONDecodeError:
                 continue
-            bid_records = self._extract_bids_from_blob(data, max_bids)
+            bid_records = self._extract_bids_from_blob(
+                data,
+                max_bids,
+                observed_at=observed_at,
+                observation_run_id=observation_run_id,
+            )
             if bid_records:
                 return bid_records
         return []
 
-    def _extract_bids_from_blob(self, data: Any, max_bids: Optional[int]) -> List[BidRecord]:
+    def _extract_bids_from_blob(
+        self,
+        data: Any,
+        max_bids: Optional[int],
+        *,
+        observed_at: Optional[str] = None,
+        observation_run_id: Optional[str] = None,
+    ) -> List[BidRecord]:
         bids: List[BidRecord] = []
 
         def traverse(node: Any) -> None:
             if isinstance(node, dict):
                 if {"bids", "project"}.issubset(node.keys()):
-                    bids.extend(self._convert_bid_payloads(node["bids"], max_bids))
+                    bids.extend(
+                        self._convert_bid_payloads(
+                            node["bids"],
+                            max_bids,
+                            observed_at=observed_at,
+                            observation_run_id=observation_run_id,
+                        )
+                    )
                 elif "bids" in node and isinstance(node["bids"], list):
-                    bids.extend(self._convert_bid_payloads(node["bids"], max_bids))
+                    bids.extend(
+                        self._convert_bid_payloads(
+                            node["bids"],
+                            max_bids,
+                            observed_at=observed_at,
+                            observation_run_id=observation_run_id,
+                        )
+                    )
                 for value in node.values():
                     traverse(value)
             elif isinstance(node, list):
@@ -439,7 +531,12 @@ class FreelancerScraper:
         return bids[:max_bids] if max_bids else bids
 
     def _convert_bid_payloads(
-        self, payloads: Sequence[Any], max_bids: Optional[int]
+        self,
+        payloads: Sequence[Any],
+        max_bids: Optional[int],
+        *,
+        observed_at: Optional[str] = None,
+        observation_run_id: Optional[str] = None,
     ) -> List[BidRecord]:
         bid_records: List[BidRecord] = []
         for payload in payloads[: max_bids or None]:
@@ -463,6 +560,9 @@ class FreelancerScraper:
                 delivery_days=self._safe_int(payload.get("period") or payload.get("delivery_time")),
                 status=payload.get("status"),
             )
+            if observed_at:
+                bid_record.observed_at = observed_at
+            bid_record.observation_run_id = observation_run_id
             bid_records.append(bid_record)
         return bid_records
 
@@ -516,11 +616,13 @@ def default_scraper_from_env() -> FreelancerScraper:
 def save_projects_to_disk(
     projects: Iterable[ProjectSummary],
     output: Path,
+    *,
+    append: bool = False,
 ) -> None:
     """Persist collected project data to JSON."""
 
     scraper = FreelancerScraper()
-    scraper.dump_to_json(projects, output)
+    scraper.dump_to_json(projects, output, append=append)
 
 
 __all__ = [
@@ -528,6 +630,7 @@ __all__ = [
     "ProjectSummary",
     "BidRecord",
     "EmployerProfile",
+    "StatusEvent",
     "default_scraper_from_env",
     "save_projects_to_disk",
 ]


### PR DESCRIPTION
## Summary
- add timestamps, run identifiers, and status tracking to project and bid records produced by the scraper
- extend the CLI and exporters with append-friendly JSON/CSV/JSONL output options for repeated runs
- document how to schedule recurring scrapes to build a longitudinal dataset

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e3c5f826ac8320bddee34715b3ee3e